### PR TITLE
Mark gh-pages/ directory to be ignored by linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+gh-pages/* linguist-vendored


### PR DESCRIPTION
This way the language statistics will come out right in GitHub. See https://github.com/github/linguist#overrides for details.

I greatly enjoyed your workshop! Thank you. :-)
